### PR TITLE
[bug fix] Only up to two people are visible upon joining/turning on the camera

### DIFF
--- a/serverless/lambda/index.js
+++ b/serverless/lambda/index.js
@@ -94,7 +94,7 @@ const endMeeting = async(title) => {
 
   console.info("deleteMeeting > params:", JSON.stringify(params, null, 2));
 
-  const result = await ddb.delete(params).promise();
+  const result = await ddb.deleteItem(params).promise();
 
   console.info("deleteMeeting > result:", JSON.stringify(result, null, 2));
 


### PR DESCRIPTION
*Description of changes:*
Only two people were shown on the UI due to how `RemoteVideoGroup` component manages raster state updates.
With this change, now up to 16 (or whatever is set for `CHIME_ROOM_MAX_ATTENDEE`) people can turn on their camera and see the other people in the meeting.

![image](https://user-images.githubusercontent.com/24555667/193231848-0e33df85-d265-49c2-bce1-396ed549f41b.png)

Another minor bug fix is also implemented with regards to DynamoDB table update. Upon invoking `endMeeting` lambda function, the meeting is supposed to be deleted from DynamoDB named `MEETING_TABLE_NAME`, but it was invoking an non-existing `ddb.delete` API instead of `ddb.deleteItem` API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
